### PR TITLE
Removed Exercise Solution

### DIFF
--- a/foundry/test/uniswap-v2/exercises/UniswapV2Factory.test.sol
+++ b/foundry/test/uniswap-v2/exercises/UniswapV2Factory.test.sol
@@ -27,7 +27,7 @@ contract UniswapV2FactoryTest is Test {
         // Exercise - deploy token + WETH pair contract
         // Write your code here
         // Don’t change any other code
-        address pair = factory.createPair(address(token), WETH);
+        address pair;
 
         address token0 = IUniswapV2Pair(pair).token0();
         address token1 = IUniswapV2Pair(pair).token1();


### PR DESCRIPTION
Accidentally gave the solution to the exercise.

`address pair = factory.createPair(address(token), WETH);` instead of `address pair;`