### PR TITLE
Removed test_removeLiquidity() from the exercise

### DIFF
--- a/foundry/test/uniswap-v2/exercises/UniswapV2Liquidity.test.sol
+++ b/foundry/test/uniswap-v2/exercises/UniswapV2Liquidity.test.sol
@@ -49,27 +49,4 @@ contract UniswapV2LiquidityTest is Test {
 
         assertGt(pair.balanceOf(user), 0, "LP = 0");
     }
-
-    function test_removeLiquidity() public {
-        vm.startPrank(user);
-        (,, uint256 liquidity) = router.addLiquidity({
-            tokenA: DAI,
-            tokenB: WETH,
-            amountADesired: 1000000 * 1e18,
-            amountBDesired: 100 * 1e18,
-            amountAMin: 1,
-            amountBMin: 1,
-            to: user,
-            deadline: block.timestamp
-        });
-
-        // Exercise - Remove liquidity from DAI / WETH pool
-        // Write your code here
-        // Don’t change any other code
-        pair.approve(address(router), liquidity);
-
-        vm.stopPrank();
-
-        assertEq(pair.balanceOf(user), 0, "LP = 0");
-    }
 }


### PR DESCRIPTION
Removed test_removeLiquidity() from the exercise because it reveals the solution for test_addLiquidity()

````
  (, , uint256 liquidity) = router.addLiquidity({
            tokenA: DAI,
            tokenB: WETH,
            amountADesired: 1000000 * 1e18,
            amountBDesired: 100 * 1e18,
            amountAMin: 1,
            amountBMin: 1,
            to: user,
            deadline: block.timestamp
        });
```