### PR TITLE
fix: update UniswapV2Arb2 test to use assertGt instead of assertGe fo…

### DIFF
--- a/foundry/test/uniswap-v2/exercises/UniswapV2Arb2.test.sol
+++ b/foundry/test/uniswap-v2/exercises/UniswapV2Arb2.test.sol
@@ -64,7 +64,7 @@ contract UniswapV2Arb2Test is Test {
         );
         uint256 bal1 = dai.balanceOf(user);
 
-        assertGe(bal1, bal0, "no profit");
+        assertGt(bal1, bal0, "no profit");
         assertEq(dai.balanceOf(address(arb)), 0, "DAI balance of arb != 0");
         console2.log("profit", bal1 - bal0);
     }


### PR DESCRIPTION
## Fix UniswapV2Arb2 Test Assertion

## Description
This PR updates the assertion in the `UniswapV2Arb2.test.sol` file to use `assertGt` instead of `assertGe` when verifying arbitrage profits. This change ensures that the test properly validates that the arbitrage strategy actually generates a profit rather than just breaking even.

## Changes Made
Changed `assertGe(bal1, bal0, "no profit")` to `assertGt(bal1, bal0, "no profit")` in the `test_flashSwap` function

## Reason for Change
The purpose of an arbitrage strategy is to generate actual profit, not just break even. Using assertGt (greater than) instead of assertGe (greater than or equal to) better aligns with the test's intention and the error message "no profit" which implies that a profit should be made.

## Testing
The test continues to pass with this stricter assertion, confirming that the arbitrage implementation is working as expected.
