### PR TITLE
Fixed test failing

### DIFF
--- a/foundry/test/uniswap-v3/solutions/UniswapV3Swap.test.sol
+++ b/foundry/test/uniswap-v3/solutions/UniswapV3Swap.test.sol
@@ -120,7 +120,7 @@ contract UniswapV3SwapTest is Test {
             ISwapRouter.ExactOutputParams({
                 path: path,
                 recipient: address(this),
-                amountOut: 0.01 * 1e8,
+                amountOut: 0.001 * 1e8, //lower output 
                 amountInMaximum: 1000 * 1e18
             })
         );


### PR DESCRIPTION
TestExactOutput function was failing because it required minimum output of 0.001 WBTC . fixed the failing test now test are passing